### PR TITLE
fix: 공통 레이아웃 헤더와 content 영역 겹침 문제 해결

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -3,6 +3,7 @@
     margin: 0;
     padding: 0;
     box-sizing: border-box;
+    color: #333333; /* 기본 글씨색 설정 */
 }
 
 html {
@@ -26,12 +27,12 @@ body {
     background-color: #fff;
     box-shadow: 0 2px 4px rgba(0, 0, 0, 0.1);
     border-radius: 10px;
-    min-height: 100vh;
+    height: auto;
     padding-top: 60px;
     padding-bottom: 60px;
     display: flex;
     flex-direction: column;
-    justify-content: space-between;
+    justify-content: flex-start;
 }
 
 /* 헤더 스타일 */
@@ -116,20 +117,13 @@ header {
 
 /* 모바일 화면 전용 스타일 */
 @media only screen and (max-width: 767px) {
-    body {
-        align-items: center;
-    }
     .main-content {
-        width: 100%;
-        height: 100vh;
-        justify-content: center;
-        padding-top: 60px;
+        height: auto;
+        min-height: calc(100vh - 60px); /* 헤더와 네비바를 제외한 높이 */
     }
-    #navbar {
-        width: 100%;
-    }
-    .bottom-nav {
-        width: 100%;
-        padding: 20px 0;
+
+    .content {
+        flex-grow: 1;
+        padding: 16px;
     }
 }


### PR DESCRIPTION
## 💻 작업 내용
- 모바일 환경에서 헤더랑 content 영역이 겹쳐서 그 부분 수정
- 기본 글씨색 #333333으로 설정

## 🛠️ 수정 사항
- 

## 📝 참고사항
- 

## 📸 화면 캡처 (선택)
- 
